### PR TITLE
Remove js.log from gridColumnStart

### DIFF
--- a/bs-emotion/src/Emotion.re
+++ b/bs-emotion/src/Emotion.re
@@ -450,10 +450,7 @@ let gridAutoColumns = x => p("gridAutoColumns", x->Grid.AutoColumns.toString);
 
 let gridRowStart = x => p("gridRowStart", x->Grid.Line.toString);
 let gridRowEnd = x => p("gridRowEnd", x->Grid.Line.toString);
-let gridColumnStart = x => {
-  Js.log(p("gridColumnStart", x->Grid.Line.toString));
-  p("gridColumnStart", x->Grid.Line.toString);
-};
+let gridColumnStart = x => p("gridColumnStart", x->Grid.Line.toString);
 let gridColumnEnd = x => p("gridColumnEnd", x->Grid.Line.toString);
 
 let gridGap = x => p("gridGap", x->LengthPercentage.toString);


### PR DESCRIPTION
Thanks for an awesome library! This is a minor fix to remove `Js.log` from inside `gridColumnStart`.